### PR TITLE
Different key handling, fixes accents/dead-keys and alt-shortcuts problems (#12)

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -72,33 +72,26 @@ const wchar_t *GetIniFilePath() {
 }
 
 static void prepareKeyboardChars() {
-	BOOL processChars[256] = { FALSE };
+	BOOL processChars[255] = { FALSE };
 
 	kbProcessChars.clear();
 
 	// Default characters
-	processChars[(CHAR) '\''] = TRUE;
-	processChars[(CHAR) '"'] = TRUE;
-	processChars[(CHAR) '('] = TRUE;
-	processChars[(CHAR) ')'] = TRUE;
-	processChars[(CHAR) '{'] = TRUE;
-	processChars[(CHAR) '}'] = TRUE;
-	processChars[(CHAR) '['] = TRUE;
-	processChars[(CHAR) ']'] = TRUE;
-	processChars[(CHAR) '`'] = TRUE;
+	for (UCHAR c : "\"'(){}[]<>`")
+		processChars[c] = TRUE;
 
 	// Add user defined
-	for (SIZE_T i = 0; i < _tcslen(addChars); i++)
+	for (SIZE_T i = 0, j = _tcslen(addChars); i < j; i++)
 		processChars[(UCHAR) addChars[i]] = TRUE;
 	
 	// Disable ignored
-	for (SIZE_T i = 0; i < _tcslen(ignoreChars); i++)
+	for (SIZE_T i = 0, j = _tcslen(ignoreChars); i < j; i++)
 		processChars[(UCHAR) ignoreChars[i]] = FALSE;
 
 	// Add all enabled into kbProcessChars
-	for (SIZE_T i = 0; i < 256; i++)
+	for (UCHAR i = 0; i < 255; i++)
 		if (processChars[i])
-			kbProcessChars.push_back((UCHAR) i);
+			kbProcessChars.push_back(i);
 }
 
 static void updateKL() {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -45,7 +45,7 @@ static LPWORD kbBuff = (LPWORD)new byte[buffChars];
 static PBYTE kbState = new byte[256];
 static std::vector<UCHAR> kbProcessChars;
 static std::vector<COMBINATION> kbProcessCombinations;
-static int kbProcessCombinationsCount;
+static size_t kbProcessCombinationsCount;
 TCHAR addChars[1024];
 TCHAR ignoreChars[1024];
 
@@ -206,7 +206,7 @@ LRESULT CALLBACK KeyboardProc(int ncode, WPARAM wparam, LPARAM lparam) {
 		goto proceed;
 
 	// Check whether any "registered" combination is pressed
-	for (int i = 0; i < kbProcessCombinationsCount; i++) {
+	for (size_t i = 0; i < kbProcessCombinationsCount; i++) {
 		COMBINATION comb = kbProcessCombinations[i];
 
 		if (((kbState[comb.vk] & 0xF0) == 0x80)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -111,7 +111,6 @@ static void updateKL() {
 		SHORT comb = VkKeyScanEx(ch, keyboardLayout);
 
 		if (comb == -1) {
-			MessageBoxA(NULL, "nope", "nope", 0);
 			continue;
 		}
 


### PR DESCRIPTION
**TLDR:** new way of detecting when surrounding should be done. It has flaws, but works perfectly on US and CZ keyboard layouts. 
Switching layouts is probably broken (not part of this code, was broken before) - you have to restart N++ to fix which keys are used for surrounding text.

---

In initialization and every KBD layout change* it loops over all surrounding characters (``"'`(){}[]<>`` + `AdditionalChars` - `IgnoreChars`) and prepares an array of keyboard state combination on which surrounding should be triggered.

I.e. for `"` it will add one `COMBINATION` struct with virtual key code and shift/alt/ctrl states needed to produce `"` on current keyboard layout.

Then in KBD procedure it loops through these combinations. If any of them matches current keyboard state, surrounding is triggered.


\* This probably doesn't work. I think `messageProc` is not processed inside plugins so at the moment it won't detect any keyboard layout changes.

---

Sadly it's still flawed and I am a bit afraid how it will work for different keyboard layouts. There are keys, which have more than one way to type. And function `VkKeyScanEx` just chooses one of them.

For example it's not possible to use `´` key (next to backspace on my keyboard) in `AdditionalChars`, because `´` character is actually translated into `ctrl+alt+9` (key above O). If you press this combination, you will get the text surrounded, but not if you press that separate `´` key.

Workaround would be to do some heavy processing beforehand - analyzing whole keyboard and finding all the combinations to type some character. And then use these combinations instead of relying on `VkKeyScanEx`.

Good source explaining all this: http://archives.miloush.net/michkap/archive/2008/09/03/8921419.html

---

I tried US KB layout and all the default characters work. Also on CZ layout. So hopefully the default characters will be okay for everyone. And I think it's still better than the previous version, which broke dead keys completely (because of flaw in another WinAPI function... it's a real pleasure to work with keyboard processing, thanks Microsoft).
